### PR TITLE
also create xml metadata file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1]
+## [0.3.0]
+
+### Added
+* A GIBS-compliant metadata XML file is now also created along with the browse GeoTIFF.
 
 ### Changed
 * Output files are now deleted from disk when running in AWS Lambda

--- a/src/opera_rtc_s1_browse/create_browse.py
+++ b/src/opera_rtc_s1_browse/create_browse.py
@@ -19,7 +19,7 @@ s3 = boto3.client('s3')
 
 
 def now() -> datetime.datetime:
-    return datetime.datetime.now()
+    return datetime.datetime.utcnow()
 
 
 def create_metadata_xml(co_pol_path: Path, browse_path: Path) -> Path:

--- a/tests/test_create_browse.py
+++ b/tests/test_create_browse.py
@@ -1,3 +1,6 @@
+import datetime
+from unittest.mock import patch
+
 import numpy as np
 
 from opera_rtc_s1_browse import create_browse
@@ -26,3 +29,29 @@ def test_create_browse_array():
     assert np.array_equal(output_array[:, :, 1], np.array([[0, 0], [180, 255], [0, 0]]))
     assert np.array_equal(output_array[:, :, 0], output_array[:, :, 2])
     assert np.array_equal(output_array[:, :, 3], np.array([[0, 0], [255, 255], [0, 0]]))
+
+
+def test_create_metadata_xml(tmp_path):
+    info = {
+        'metadata': {
+            '': {
+                'ZERO_DOPPLER_START_TIME': '2024-01-13T02:08:16.123456Z',
+                'ZERO_DOPPLER_END_TIME': '2024-01-13T02:08:19.987654',
+            }
+        }
+    }
+    with patch('opera_rtc_s1_browse.create_browse.now', return_value=datetime.datetime(2024, 6, 14, 6, 4, 32, 234)):
+        with patch('osgeo.gdal.Info', return_value=info):
+            co_pol_path = tmp_path / 'vv.tif'
+            browse_path = tmp_path / 'browse.tif'
+            metadata_path = create_browse.create_metadata_xml(co_pol_path, browse_path)
+    assert metadata_path == tmp_path / 'browse.xml'
+    assert metadata_path.read_text() == (
+        '<ImageryMetadata xmlns="http://www.w3.org/2005/Atom" xmlns:georss="http://www.georss.org/georss/10">\n'
+        '  <ProviderProductId>browse</ProviderProductId>\n'
+        '  <ProductionDateTime>2024-06-14T06:04:32Z</ProductionDateTime>\n'
+        '  <DataStartDateTime>2024-01-13T02:08:16Z</DataStartDateTime>\n'
+        '  <DataEndDateTime>2024-01-13T02:08:19Z</DataEndDateTime>\n'
+        '  <DataDay>20240113</DataDay>\n'
+        '</ImageryMetadata>\n'
+    )


### PR DESCRIPTION
See TOOL-2818 for requirements.

I could be talked into a jinja2 template for the xml contents; this is a borderline case for me whether it's worth the effort.

The datetime logic might be a little easier if we confirm GIBS can accept dates with microseconds and alternate timezone formats (e.g. `+00:00`). Then we could use the ZERO_DOPPLER values unmodified.