### PR TITLE
remove obsolete DAR tag from s3 bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * Output files are now deleted from disk when running in AWS Lambda
+### Removed
+* Obsolete `DAR` tag from S3 bucket
 
 ## [0.2.0]
 

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -17,9 +17,6 @@ Resources:
           - Status: Enabled
             AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 1
-      Tags:
-        - Key: DAR
-          Value: "NO"
 
   Lambda:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
The DAR tag was previously required in EDC environments to help inventory buckets with un-encrypted objects. All new buckets/object since 2023 are automatically encrypted, so per the EDC team the tag isn't required going forward.