### PR TITLE
move sqrt out of normalize_image_array and use more specific tests

### DIFF
--- a/src/opera_rtc_s1_browse/create_browse.py
+++ b/src/opera_rtc_s1_browse/create_browse.py
@@ -45,20 +45,18 @@ def download_data(granule: str, working_dir: Path) -> tuple[Path, Path]:
 
 
 def normalize_image_array(input_array: np.ndarray, vmin: float, vmax: float) -> np.ndarray:
-    """Function to normalize a browse image band.
-    Modified from OPERA-ADT/RTC.
+    """Function to normalize array values to a byte value between 0 and 255
 
     Args:
         input_array: The array to normalize.
-        vmin: The minimum value to normalize to.
-        vmax: The maximum value to normalize to.
+        vmin: The minimum value to normalize to (mapped to 0).
+        vmax: The maximum value to normalize to (mapped to 255).
 
     Returns
         The normalized array.
     """
     input_array = input_array.astype(float)
-    amplitude_array = np.sqrt(input_array)
-    scaled_array = (amplitude_array - vmin) / (vmax - vmin)
+    scaled_array = (input_array - vmin) / (vmax - vmin)
     scaled_array[np.isnan(input_array)] = 0
     normalized_array = np.round(np.clip(scaled_array, 0, 1) * 255).astype(np.uint8)
     return normalized_array
@@ -66,7 +64,7 @@ def normalize_image_array(input_array: np.ndarray, vmin: float, vmax: float) -> 
 
 def create_browse_array(co_pol_array: np.ndarray, cross_pol_array: np.ndarray) -> np.ndarray:
     """Create a browse image array for an OPERA S1 RTC granule.
-    Bands are normalized and follow the format: [co-pol, cross-pol, co-pol, no-data].
+    Input arrays are converted to amplitude, normalized, and returned as [co-pol, cross-pol, co-pol, no-data].
 
     Args:
         co_pol_array: Co-pol image array.
@@ -77,11 +75,13 @@ def create_browse_array(co_pol_array: np.ndarray, cross_pol_array: np.ndarray) -
     """
     co_pol_range = [0.14, 0.52]
     co_pol_nodata = ~np.isnan(co_pol_array)
-    co_pol = normalize_image_array(co_pol_array, *co_pol_range)
+    co_pol_amplitude = np.sqrt(co_pol_array)
+    co_pol = normalize_image_array(co_pol_amplitude, *co_pol_range)
 
     cross_pol_range = [0.05, 0.259]
     cross_pol_nodata = ~np.isnan(cross_pol_array)
-    cross_pol = normalize_image_array(cross_pol_array, *cross_pol_range)
+    cross_pol_amplitude = np.sqrt(cross_pol_array)
+    cross_pol = normalize_image_array(cross_pol_amplitude, *cross_pol_range)
 
     no_data = (np.logical_and(co_pol_nodata, cross_pol_nodata) * 255).astype(np.uint8)
     browse_image = np.stack([co_pol, cross_pol, co_pol, no_data], axis=-1)

--- a/tests/test_create_browse.py
+++ b/tests/test_create_browse.py
@@ -4,22 +4,21 @@ from opera_rtc_s1_browse import create_browse
 
 
 def test_normalize_image_array():
-    input_array = np.arange(0, 3) ** 2
-    golden_array = np.array([0, 128, 255])
+    input_array = np.array([0.0, 1.0, 2.0, np.nan])
     output_array = create_browse.normalize_image_array(input_array, 0, 2)
-    assert np.array_equal(output_array, golden_array)
+    assert np.array_equal(output_array, np.array([0, 128, 255, 0]))
 
-    input_array = np.append(input_array.astype(float), np.nan)
-    golden_array = np.append(golden_array, 0)
-    output_array = create_browse.normalize_image_array(input_array, 0, 2)
-    assert np.array_equal(output_array, golden_array)
+    input_array = np.array([-10.0, -0.001, 0.0, 0.0001, 0.04, 2.0, 5.0, 9.999, 10.0, 10.001, 94.0, np.nan])
+    output = create_browse.normalize_image_array(input_array, 0.0, 10.0)
+    assert np.array_equal(output, np.array([0, 0, 0, 0, 1, 51, 128, 255, 255, 255, 255, 0]))
+
+    output = create_browse.normalize_image_array(input_array, 1.0, 9.0)
+    assert np.array_equal(output, np.array([0, 0, 0, 0, 0, 32, 128, 255, 255, 255, 255, 0]))
 
 
 def test_create_browse_array():
-    vv_min, vv_max = 0.14, 0.52
-    test_vv = np.array([[0, vv_min**2, ((vv_min + vv_max - 0.001) / 2) ** 2, vv_max**2, np.nan]])
-    vh_min, vh_max = 0.05, 0.259
-    test_vh = np.array([[np.nan, 0, vh_min**2, ((vh_min + vh_max - 0.001) / 2) ** 2, vh_max**2]])
+    test_vv = np.array([[0, 0.0196, 0.10857025, 0.2704, np.nan]])
+    test_vh = np.array([[np.nan, 0.0, 0.0025, 0.023716, 0.067081]])
     output_array = create_browse.create_browse_array(test_vv, test_vh)
     assert output_array.shape == (1, 5, 4)
     assert np.array_equal(output_array[:, :, 0], np.array([[0, 0, 127, 255, 0]]))


### PR DESCRIPTION
Including the sqrt converting from power to amplitude out of normalize_image_array makes testing that function easier, since the test cases only have to worry about normalization.

I prefer using as many literal values as possible in tests; putting too much code in tests often amounts to copy/pasting the implementation.